### PR TITLE
added for loop for removing votes from uninstalled packages

### DIFF
--- a/aur-auto-vote
+++ b/aur-auto-vote
@@ -109,6 +109,17 @@ def main(arguments):
             print('failed.')
         time.sleep(arguments.delay)
 
+    for package in sorted(set(voted_packages).difference(foreign_packages)):
+        if any(i.match(package) for i in ignores):
+            print('Ignoring package:', package)
+            continue
+
+        print('Unvoting for package: %s... ' % package, end='', flush=True)
+        if unvote_package(session, token, package):
+            print('done.')
+        else:
+            print('failed.')
+        time.sleep(arguments.delay)
 
 if __name__ == '__main__':
     arguments = argument_parser.parse_args()


### PR DESCRIPTION
Small change so that the votes in aur reflect the packages actually installed in the system at the moment the script is run, that way you don't need to worry about any kind of voting/unvoting at all(if you have a weekly service like i do). I made this pull request in case you might be interested.
