### PR TITLE
aur-auto-vote: ignore debug packages while voting

### DIFF
--- a/aur-auto-vote
+++ b/aur-auto-vote
@@ -15,6 +15,7 @@ EXIT_FAILURE = 1
 LOGIN_URL = 'https://aur.archlinux.org/login'
 SEARCH_URL_TEMPLATE = 'https://aur.archlinux.org/packages/?O=%d&SB=w&SO=d&PP=250&do_Search=Go'
 PACKAGES_URL = 'https://aur.archlinux.org/packages/'
+PAKCAGE_SEARCH_URL_TEMPLATE = 'https://aur.archlinux.org/packages/?O=0&SeB=n&K=%s&SB=n&PP=250&do_Search=Go'
 VOTE_URL_TEMPLATE = 'https://aur.archlinux.org/pkgbase/%s/vote/'
 UNVOTE_URL_TEMPLATE = 'https://aur.archlinux.org/pkgbase/%s/unvote/'
 PACKAGES_PER_PAGE = 250
@@ -70,6 +71,11 @@ def unvote_package(session, package):
     return response.status_code == requests.codes.ok
 
 
+def check_aur_exist(session, package):
+    response = session.get(PAKCAGE_SEARCH_URL_TEMPLATE % package)
+    soup = bs4.BeautifulSoup(response.text, 'html5lib').select_one('#pkglist-results-form > table > tbody > tr:nth-child(1) > td:nth-child(1) > a').get_text()
+    return soup.strip() == package
+
 # TODO: Handle split packages better
 def main(arguments):
     password = os.environ.get('AUR_AUTO_VOTE_PASSWORD') or getpass.getpass('Password: ')
@@ -101,7 +107,8 @@ def main(arguments):
 
         # Ignore -debug packages
         if ('-debug' in package) and (package[:-6] in foreign_packages):
-            continue
+            if not check_aur_exist(package): 
+                continue
 
         print('Voting for package: %s... ' % package, end='', flush=True)
         if vote_package(session, package):

--- a/aur-auto-vote
+++ b/aur-auto-vote
@@ -99,6 +99,10 @@ def main(arguments):
             print('Not voting for ignored package:', package)
             continue
 
+        # Ignore -debug packages
+        if ('-debug' in package) and (package[:-6] in foreign_packages):
+            continue
+
         print('Voting for package: %s... ' % package, end='', flush=True)
         if vote_package(session, package):
             print('done.')

--- a/aur-auto-vote
+++ b/aur-auto-vote
@@ -73,8 +73,13 @@ def unvote_package(session, package):
 
 def check_aur_exist(session, package):
     response = session.get(PAKCAGE_SEARCH_URL_TEMPLATE % package)
-    soup = bs4.BeautifulSoup(response.text, 'html5lib').select_one('#pkglist-results-form > table > tbody > tr:nth-child(1) > td:nth-child(1) > a').get_text()
-    return soup.strip() == package
+    soup = bs4.BeautifulSoup(response.text, 'html5lib').select_one('#pkglist-results-form > table > tbody > tr:nth-child(1) > td:nth-child(1) > a')
+    if soup is None:
+        return False
+    else:
+        name = soup.get_text() 
+        return name.strip() == package
+
 
 # TODO: Handle split packages better
 def main(arguments):
@@ -107,7 +112,7 @@ def main(arguments):
 
         # Ignore -debug packages
         if ('-debug' in package) and (package[:-6] in foreign_packages):
-            if not check_aur_exist(package): 
+            if not check_aur_exist(session, package): 
                 continue
 
         print('Voting for package: %s... ' % package, end='', flush=True)


### PR DESCRIPTION
Ignores debug packages while voting

Before:
```
$ aur-auto-vote hanatomizu
Password: 
Voting for package: blockbench-bin-debug... failed.
Voting for package: giblib-debug... failed.
Voting for package: linuxqq-debug... failed.
Voting for package: osu-lazer-debug... failed.
Voting for package: plasma6-applets-window-buttons-debug... failed.
Voting for package: snapd-xdg-open-git-debug... failed.
Voting for package: wps-office-debug... failed.
Voting for package: yesplaymusic-debug... failed.
```

After:
```
$ aur-auto-vote hanatomizu
Password: 
```